### PR TITLE
Release handlerPointer

### DIFF
--- a/Sources/Unrar/Archive.swift
+++ b/Sources/Unrar/Archive.swift
@@ -150,6 +150,7 @@ public class Archive {
             throw UnrarError.badArchive
         }
         defer {
+            Unmanaged<Callback>.fromOpaque(handlerPointer).release()
             RARCloseArchive(data)
         }
         loop: repeat {


### PR DESCRIPTION
Reduced my memory allocation in a sample test run from 1.4GB to 40MB, so I think this helps fix the memory leak. 