### PR TITLE
Binary target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 /Packages
 /*.xcodeproj
 xcuserdata/
+
+# xcframework
+/build/
+/Cunrar.xcframework/
+/Cunrar.zip

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+TARGET=Cunrar.xcframework
+ZIP=Cunrar.zip
+FRAMEWORK_MACOS=build/Release/Cunrar.framework
+FRAMEWORK_IPHONEOS=build/Release-iphoneos/Cunrar.framework
+FRAMEWORK_IPHONESIMULATOR=build/Release-iphonesimulator/Cunrar.framework
+
+all: $(TARGET)
+
+clean:
+	rm -rf $(TARGET) $(FRAMEWORK_MACOS) $(FRAMEWORK_IPHONEOS) $(FRAMEWORK_IPHONESIMULATOR)
+
+$(ZIP): $(TARGET)
+	zip -r $@ $<
+	shasum -a 256 $@
+
+$(TARGET): $(FRAMEWORK_MACOS) $(FRAMEWORK_IPHONEOS) $(FRAMEWORK_IPHONESIMULATOR)
+	xcodebuild -create-xcframework -output $@ -framework $(FRAMEWORK_MACOS) -framework $(FRAMEWORK_IPHONEOS) -framework $(FRAMEWORK_IPHONESIMULATOR)
+
+$(FRAMEWORK_MACOS):
+	xcodebuild -sdk macosx -target Cunrar build
+
+$(FRAMEWORK_IPHONEOS):
+	xcodebuild -sdk iphoneos -target Cunrar build
+
+$(FRAMEWORK_IPHONESIMULATOR):
+	xcodebuild -sdk iphonesimulator -target Cunrar build

--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let cunrar = Target.target(
             ]
         )
 #else
-let cunrar = Target.binaryTarget(name: "Cunrar", url: "https://github.com/mtgto/Unrar.swift/releases/download/0.3.9/Cunrar.zip", checksum: "2d819e9218d9292be9f2ebcb1a3b7bd21250d165cc8b6869a1b1ba38144df4db")
+let cunrar = Target.binaryTarget(name: "Cunrar", url: "https://github.com/mtgto/Unrar.swift/releases/download/0.2.2/Cunrar.zip", checksum: "a8baa5850c5ba21e1b88e57cc0eeb6957c97f2e5fdb7ed339fb18813ed1c22c4")
 #endif
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // SPDX-FileCopyrightText: 2021 mtgto <hogerappa@gmail.com>
 // SPDX-License-Identifier: MIT
 

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,48 @@
 
 import PackageDescription
 
+#if os(Linux)
+let cunrar = Target.target(
+            name: "Cunrar",
+            exclude: [
+                "readme.txt", "license.txt", "acknow.txt",
+                "arccmt.cpp", "blake2s_sse.cpp", "blake2sp.cpp", "cmdfilter.cpp", "cmdmix.cpp", "coder.cpp", "crypt1.cpp", "crypt2.cpp",
+                "crypt3.cpp", "crypt5.cpp", "hardlinks.cpp", "isnt.cpp", "log.cpp", "model.cpp", "rarpch.cpp", "recvol3.cpp", "recvol5.cpp", "suballoc.cpp",
+                "threadmisc.cpp", "uicommon.cpp", "uiconsole.cpp", "uisilent.cpp", "ulinks.cpp", "unpack15.cpp", "unpack20.cpp", "unpack30.cpp",
+                "unpack50.cpp", "unpack50frag.cpp", "unpack50mt.cpp", "unpackinline.cpp", "uowners.cpp", "win32acl.cpp", "win32lnk.cpp",
+                "win32stm.cpp",
+                "rs.cpp", "recvol.cpp",
+                "archive.hpp", "consio.hpp", "extract.hpp", "global.hpp", "log.hpp", "rar.hpp", "rawread.hpp", "savepos.hpp", "strlist.hpp",
+                "unpack.hpp", "crc.hpp", "filcreat.hpp", "hash.hpp", "match.hpp", "rardefs.hpp", "rdwrfn.hpp", "scantree.hpp",
+                "suballoc.hpp", "version.hpp", "array.hpp", "crypt.hpp", "file.hpp", "headers.hpp", "model.hpp", "rarlang.hpp", "recvol.hpp",
+                "secpassword.hpp", "system.hpp", "volume.hpp", "blake2s.hpp", "dll.hpp", "filefn.hpp", "headers5.hpp", "options.hpp", "raros.hpp",
+                "resource.hpp", "sha1.hpp", "threadpool.hpp", "cmddata.hpp", "encname.hpp", "filestr.hpp", "isnt.hpp", "os.hpp", "rartypes.hpp",
+                "rijndael.hpp", "sha256.hpp", "timefn.hpp", "coder.hpp", "errhnd.hpp", "find.hpp", "list.hpp", "pathfn.hpp", "rarvm.hpp", "rs.hpp",
+                "smallfn.hpp", "ui.hpp", "compress.hpp", "extinfo.hpp", "getbits.hpp", "loclang.hpp", "qopen.hpp", "rawint.hpp", "rs16.hpp",
+                "strfn.hpp", "unicode.hpp",
+            ],
+            sources: [
+                "include/unrar.h",
+                // LIB_OBJ
+                "filestr.cpp", "scantree.cpp", "dll.cpp", "qopen.cpp",
+                // OBJECTS
+                "rar.cpp", "strlist.cpp", "strfn.cpp", "pathfn.cpp", "smallfn.cpp", "global.cpp", "file.cpp", "filefn.cpp", "filcreat.cpp",
+                "archive.cpp", "arcread.cpp", "unicode.cpp", "system.cpp", "crypt.cpp", "crc.cpp", "rawread.cpp", "encname.cpp",
+                "resource.cpp", "match.cpp", "timefn.cpp", "rdwrfn.cpp", "consio.cpp", "options.cpp", "errhnd.cpp", "rarvm.cpp", "secpassword.cpp",
+                "rijndael.cpp", "getbits.cpp", "sha1.cpp", "sha256.cpp", "blake2s.cpp", "hash.cpp", "extinfo.cpp", "extract.cpp", "volume.cpp",
+                "list.cpp", "find.cpp", "unpack.cpp", "headers.cpp", "threadpool.cpp", "rs16.cpp", "cmddata.cpp", "ui.cpp",
+            ],
+            publicHeadersPath: "include",
+            cSettings: [
+                .define("RARDLL"),
+                .define("_FILE_OFFSET_BITS", to: "64"),
+                .define("_LARGEFILE_SOURCE"),
+            ]
+        )
+#else
+let cunrar = Target.binaryTarget(name: "Cunrar", url: "https://github.com/mtgto/Unrar.swift/releases/download/0.3.9/Cunrar.zip", checksum: "2d819e9218d9292be9f2ebcb1a3b7bd21250d165cc8b6869a1b1ba38144df4db")
+#endif
+
 let package = Package(
     name: "Unrar",
     platforms: [
@@ -19,44 +61,7 @@ let package = Package(
         .target(
             name: "Unrar",
             dependencies: ["Cunrar"]),
-        .binaryTarget(name: "Cunrar", url: "https://github.com/mtgto/Unrar.swift/releases/download/0.3.9/Cunrar.zip", checksum: "2d819e9218d9292be9f2ebcb1a3b7bd21250d165cc8b6869a1b1ba38144df4db"),
-        // .target(
-        //     name: "Cunrar",
-        //     exclude: [
-        //         "readme.txt", "license.txt", "acknow.txt",
-        //         "arccmt.cpp", "blake2s_sse.cpp", "blake2sp.cpp", "cmdfilter.cpp", "cmdmix.cpp", "coder.cpp", "crypt1.cpp", "crypt2.cpp",
-        //         "crypt3.cpp", "crypt5.cpp", "hardlinks.cpp", "isnt.cpp", "log.cpp", "model.cpp", "rarpch.cpp", "recvol3.cpp", "recvol5.cpp", "suballoc.cpp",
-        //         "threadmisc.cpp", "uicommon.cpp", "uiconsole.cpp", "uisilent.cpp", "ulinks.cpp", "unpack15.cpp", "unpack20.cpp", "unpack30.cpp",
-        //         "unpack50.cpp", "unpack50frag.cpp", "unpack50mt.cpp", "unpackinline.cpp", "uowners.cpp", "win32acl.cpp", "win32lnk.cpp",
-        //         "win32stm.cpp",
-        //         "rs.cpp", "recvol.cpp",
-        //         "archive.hpp", "consio.hpp", "extract.hpp", "global.hpp", "log.hpp", "rar.hpp", "rawread.hpp", "savepos.hpp", "strlist.hpp",
-        //         "unpack.hpp", "crc.hpp", "filcreat.hpp", "hash.hpp", "match.hpp", "rardefs.hpp", "rdwrfn.hpp", "scantree.hpp",
-        //         "suballoc.hpp", "version.hpp", "array.hpp", "crypt.hpp", "file.hpp", "headers.hpp", "model.hpp", "rarlang.hpp", "recvol.hpp",
-        //         "secpassword.hpp", "system.hpp", "volume.hpp", "blake2s.hpp", "dll.hpp", "filefn.hpp", "headers5.hpp", "options.hpp", "raros.hpp",
-        //         "resource.hpp", "sha1.hpp", "threadpool.hpp", "cmddata.hpp", "encname.hpp", "filestr.hpp", "isnt.hpp", "os.hpp", "rartypes.hpp",
-        //         "rijndael.hpp", "sha256.hpp", "timefn.hpp", "coder.hpp", "errhnd.hpp", "find.hpp", "list.hpp", "pathfn.hpp", "rarvm.hpp", "rs.hpp",
-        //         "smallfn.hpp", "ui.hpp", "compress.hpp", "extinfo.hpp", "getbits.hpp", "loclang.hpp", "qopen.hpp", "rawint.hpp", "rs16.hpp",
-        //         "strfn.hpp", "unicode.hpp",
-        //     ],
-        //     sources: [
-        //         "include/unrar.h",
-        //         // LIB_OBJ
-        //         "filestr.cpp", "scantree.cpp", "dll.cpp", "qopen.cpp",
-        //         // OBJECTS
-        //         "rar.cpp", "strlist.cpp", "strfn.cpp", "pathfn.cpp", "smallfn.cpp", "global.cpp", "file.cpp", "filefn.cpp", "filcreat.cpp",
-        //         "archive.cpp", "arcread.cpp", "unicode.cpp", "system.cpp", "crypt.cpp", "crc.cpp", "rawread.cpp", "encname.cpp",
-        //         "resource.cpp", "match.cpp", "timefn.cpp", "rdwrfn.cpp", "consio.cpp", "options.cpp", "errhnd.cpp", "rarvm.cpp", "secpassword.cpp",
-        //         "rijndael.cpp", "getbits.cpp", "sha1.cpp", "sha256.cpp", "blake2s.cpp", "hash.cpp", "extinfo.cpp", "extract.cpp", "volume.cpp",
-        //         "list.cpp", "find.cpp", "unpack.cpp", "headers.cpp", "threadpool.cpp", "rs16.cpp", "cmddata.cpp", "ui.cpp",
-        //     ],
-        //     publicHeadersPath: "include",
-        //     cSettings: [
-        //         .define("RARDLL"),
-        //         .define("_FILE_OFFSET_BITS", to: "64"),
-        //         .define("_LARGEFILE_SOURCE"),
-        //     ]
-        // ),
+        cunrar,
         .testTarget(
             name: "UnrarTests",
             dependencies: ["Unrar"],

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,10 @@ import PackageDescription
 
 let package = Package(
     name: "Unrar",
+    platforms: [
+        .iOS(.v12),
+        .macOS(.v10_15)
+    ],
     products: [
         .library(
             name: "Unrar",
@@ -15,6 +19,7 @@ let package = Package(
         .target(
             name: "Unrar",
             dependencies: ["Cunrar"]),
+        // .binaryTarget(name: "Cunrar", url: "https://github.com/mtgto/ExampleSwiftPackage/releases/download/x.x.x/Cunrar.zip", checksum: ""),
         .target(
             name: "Cunrar",
             exclude: [
@@ -35,6 +40,7 @@ let package = Package(
                 "strfn.hpp", "unicode.hpp",
             ],
             sources: [
+                "include/unrar.h",
                 // LIB_OBJ
                 "filestr.cpp", "scantree.cpp", "dll.cpp", "qopen.cpp",
                 // OBJECTS
@@ -44,6 +50,7 @@ let package = Package(
                 "rijndael.cpp", "getbits.cpp", "sha1.cpp", "sha256.cpp", "blake2s.cpp", "hash.cpp", "extinfo.cpp", "extract.cpp", "volume.cpp",
                 "list.cpp", "find.cpp", "unpack.cpp", "headers.cpp", "threadpool.cpp", "rs16.cpp", "cmddata.cpp", "ui.cpp",
             ],
+            publicHeadersPath: "include",
             cSettings: [
                 .define("RARDLL"),
                 .define("_FILE_OFFSET_BITS", to: "64"),

--- a/Package.swift
+++ b/Package.swift
@@ -19,44 +19,44 @@ let package = Package(
         .target(
             name: "Unrar",
             dependencies: ["Cunrar"]),
-        // .binaryTarget(name: "Cunrar", url: "https://github.com/mtgto/ExampleSwiftPackage/releases/download/x.x.x/Cunrar.zip", checksum: ""),
-        .target(
-            name: "Cunrar",
-            exclude: [
-                "readme.txt", "license.txt", "acknow.txt",
-                "arccmt.cpp", "blake2s_sse.cpp", "blake2sp.cpp", "cmdfilter.cpp", "cmdmix.cpp", "coder.cpp", "crypt1.cpp", "crypt2.cpp",
-                "crypt3.cpp", "crypt5.cpp", "hardlinks.cpp", "isnt.cpp", "log.cpp", "model.cpp", "rarpch.cpp", "recvol3.cpp", "recvol5.cpp", "suballoc.cpp",
-                "threadmisc.cpp", "uicommon.cpp", "uiconsole.cpp", "uisilent.cpp", "ulinks.cpp", "unpack15.cpp", "unpack20.cpp", "unpack30.cpp",
-                "unpack50.cpp", "unpack50frag.cpp", "unpack50mt.cpp", "unpackinline.cpp", "uowners.cpp", "win32acl.cpp", "win32lnk.cpp",
-                "win32stm.cpp",
-                "rs.cpp", "recvol.cpp",
-                "archive.hpp", "consio.hpp", "extract.hpp", "global.hpp", "log.hpp", "rar.hpp", "rawread.hpp", "savepos.hpp", "strlist.hpp",
-                "unpack.hpp", "crc.hpp", "filcreat.hpp", "hash.hpp", "match.hpp", "rardefs.hpp", "rdwrfn.hpp", "scantree.hpp",
-                "suballoc.hpp", "version.hpp", "array.hpp", "crypt.hpp", "file.hpp", "headers.hpp", "model.hpp", "rarlang.hpp", "recvol.hpp",
-                "secpassword.hpp", "system.hpp", "volume.hpp", "blake2s.hpp", "dll.hpp", "filefn.hpp", "headers5.hpp", "options.hpp", "raros.hpp",
-                "resource.hpp", "sha1.hpp", "threadpool.hpp", "cmddata.hpp", "encname.hpp", "filestr.hpp", "isnt.hpp", "os.hpp", "rartypes.hpp",
-                "rijndael.hpp", "sha256.hpp", "timefn.hpp", "coder.hpp", "errhnd.hpp", "find.hpp", "list.hpp", "pathfn.hpp", "rarvm.hpp", "rs.hpp",
-                "smallfn.hpp", "ui.hpp", "compress.hpp", "extinfo.hpp", "getbits.hpp", "loclang.hpp", "qopen.hpp", "rawint.hpp", "rs16.hpp",
-                "strfn.hpp", "unicode.hpp",
-            ],
-            sources: [
-                "include/unrar.h",
-                // LIB_OBJ
-                "filestr.cpp", "scantree.cpp", "dll.cpp", "qopen.cpp",
-                // OBJECTS
-                "rar.cpp", "strlist.cpp", "strfn.cpp", "pathfn.cpp", "smallfn.cpp", "global.cpp", "file.cpp", "filefn.cpp", "filcreat.cpp",
-                "archive.cpp", "arcread.cpp", "unicode.cpp", "system.cpp", "crypt.cpp", "crc.cpp", "rawread.cpp", "encname.cpp",
-                "resource.cpp", "match.cpp", "timefn.cpp", "rdwrfn.cpp", "consio.cpp", "options.cpp", "errhnd.cpp", "rarvm.cpp", "secpassword.cpp",
-                "rijndael.cpp", "getbits.cpp", "sha1.cpp", "sha256.cpp", "blake2s.cpp", "hash.cpp", "extinfo.cpp", "extract.cpp", "volume.cpp",
-                "list.cpp", "find.cpp", "unpack.cpp", "headers.cpp", "threadpool.cpp", "rs16.cpp", "cmddata.cpp", "ui.cpp",
-            ],
-            publicHeadersPath: "include",
-            cSettings: [
-                .define("RARDLL"),
-                .define("_FILE_OFFSET_BITS", to: "64"),
-                .define("_LARGEFILE_SOURCE"),
-            ]
-        ),
+        .binaryTarget(name: "Cunrar", url: "https://github.com/mtgto/Unrar.swift/releases/download/0.3.9/Cunrar.zip", checksum: "2d819e9218d9292be9f2ebcb1a3b7bd21250d165cc8b6869a1b1ba38144df4db"),
+        // .target(
+        //     name: "Cunrar",
+        //     exclude: [
+        //         "readme.txt", "license.txt", "acknow.txt",
+        //         "arccmt.cpp", "blake2s_sse.cpp", "blake2sp.cpp", "cmdfilter.cpp", "cmdmix.cpp", "coder.cpp", "crypt1.cpp", "crypt2.cpp",
+        //         "crypt3.cpp", "crypt5.cpp", "hardlinks.cpp", "isnt.cpp", "log.cpp", "model.cpp", "rarpch.cpp", "recvol3.cpp", "recvol5.cpp", "suballoc.cpp",
+        //         "threadmisc.cpp", "uicommon.cpp", "uiconsole.cpp", "uisilent.cpp", "ulinks.cpp", "unpack15.cpp", "unpack20.cpp", "unpack30.cpp",
+        //         "unpack50.cpp", "unpack50frag.cpp", "unpack50mt.cpp", "unpackinline.cpp", "uowners.cpp", "win32acl.cpp", "win32lnk.cpp",
+        //         "win32stm.cpp",
+        //         "rs.cpp", "recvol.cpp",
+        //         "archive.hpp", "consio.hpp", "extract.hpp", "global.hpp", "log.hpp", "rar.hpp", "rawread.hpp", "savepos.hpp", "strlist.hpp",
+        //         "unpack.hpp", "crc.hpp", "filcreat.hpp", "hash.hpp", "match.hpp", "rardefs.hpp", "rdwrfn.hpp", "scantree.hpp",
+        //         "suballoc.hpp", "version.hpp", "array.hpp", "crypt.hpp", "file.hpp", "headers.hpp", "model.hpp", "rarlang.hpp", "recvol.hpp",
+        //         "secpassword.hpp", "system.hpp", "volume.hpp", "blake2s.hpp", "dll.hpp", "filefn.hpp", "headers5.hpp", "options.hpp", "raros.hpp",
+        //         "resource.hpp", "sha1.hpp", "threadpool.hpp", "cmddata.hpp", "encname.hpp", "filestr.hpp", "isnt.hpp", "os.hpp", "rartypes.hpp",
+        //         "rijndael.hpp", "sha256.hpp", "timefn.hpp", "coder.hpp", "errhnd.hpp", "find.hpp", "list.hpp", "pathfn.hpp", "rarvm.hpp", "rs.hpp",
+        //         "smallfn.hpp", "ui.hpp", "compress.hpp", "extinfo.hpp", "getbits.hpp", "loclang.hpp", "qopen.hpp", "rawint.hpp", "rs16.hpp",
+        //         "strfn.hpp", "unicode.hpp",
+        //     ],
+        //     sources: [
+        //         "include/unrar.h",
+        //         // LIB_OBJ
+        //         "filestr.cpp", "scantree.cpp", "dll.cpp", "qopen.cpp",
+        //         // OBJECTS
+        //         "rar.cpp", "strlist.cpp", "strfn.cpp", "pathfn.cpp", "smallfn.cpp", "global.cpp", "file.cpp", "filefn.cpp", "filcreat.cpp",
+        //         "archive.cpp", "arcread.cpp", "unicode.cpp", "system.cpp", "crypt.cpp", "crc.cpp", "rawread.cpp", "encname.cpp",
+        //         "resource.cpp", "match.cpp", "timefn.cpp", "rdwrfn.cpp", "consio.cpp", "options.cpp", "errhnd.cpp", "rarvm.cpp", "secpassword.cpp",
+        //         "rijndael.cpp", "getbits.cpp", "sha1.cpp", "sha256.cpp", "blake2s.cpp", "hash.cpp", "extinfo.cpp", "extract.cpp", "volume.cpp",
+        //         "list.cpp", "find.cpp", "unpack.cpp", "headers.cpp", "threadpool.cpp", "rs16.cpp", "cmddata.cpp", "ui.cpp",
+        //     ],
+        //     publicHeadersPath: "include",
+        //     cSettings: [
+        //         .define("RARDLL"),
+        //         .define("_FILE_OFFSET_BITS", to: "64"),
+        //         .define("_LARGEFILE_SOURCE"),
+        //     ]
+        // ),
         .testTarget(
             name: "UnrarTests",
             dependencies: ["Unrar"],

--- a/Sources/Cunrar/module.modulemap
+++ b/Sources/Cunrar/module.modulemap
@@ -1,0 +1,4 @@
+framework module Cunrar {
+   umbrella header "unrar.h"
+   export *
+}


### PR DESCRIPTION
#4 I build & upload `Cunrar.xcframework`.

You can use precompiled Unrar.swift now:

```swift:Package.swift
// swift-tools-version: 5.6

import PackageDescription

let package = Package(
    name: "ExampleUseCunrar",
    platforms: [
        .macOS(.v12)
    ],
    dependencies: [
        .package(url: "https://github.com/mtgto/Unrar.swift", branch: "binary-target")
    ],
    targets: [
        .executableTarget(
            name: "ExampleUseCunrar",
            dependencies: [.product(name: "Unrar", package: "Unrar.swift")])
        )
    ]
)

```