### PR TITLE
Fixes crash encountered in iOS 16

### DIFF
--- a/Sources/Unrar/Entry.swift
+++ b/Sources/Unrar/Entry.swift
@@ -14,8 +14,10 @@ public struct Entry: Equatable {
     public let modified: Date
 
     init(_ header: RARHeaderDataEx) {
-        let _header: RARHeaderDataEx = header
-        self.fileName = String(_header.FileName.0.description.unicodeScalars)
+        var _header: RARHeaderDataEx = header
+        self.fileName = withUnsafePointer(to: &_header.FileName.0) { ptr -> String in
+            return String(cString: UnsafeRawPointer(ptr).assumingMemoryBound(to: CChar.self))
+        }
         self.comment = _header.CmtBuf != nil ? String(cString: _header.CmtBuf) : nil
         self.uncompressedSize = UInt64(header.UnpSizeHigh) << 32 | UInt64(header.UnpSize)
         self.compressedSize = UInt64(header.PackSizeHigh) << 32 | UInt64(header.PackSize)

--- a/Sources/Unrar/Entry.swift
+++ b/Sources/Unrar/Entry.swift
@@ -14,8 +14,8 @@ public struct Entry: Equatable {
     public let modified: Date
 
     init(_ header: RARHeaderDataEx) {
-        var _header: RARHeaderDataEx = header
-        self.fileName = String(cString: &_header.FileName.0)
+        let _header: RARHeaderDataEx = header
+        self.fileName = String(_header.FileName.0.description.unicodeScalars)
         self.comment = _header.CmtBuf != nil ? String(cString: _header.CmtBuf) : nil
         self.uncompressedSize = UInt64(header.UnpSizeHigh) << 32 | UInt64(header.UnpSize)
         self.compressedSize = UInt64(header.PackSizeHigh) << 32 | UInt64(header.PackSize)

--- a/Sources/Unrar/Entry.swift
+++ b/Sources/Unrar/Entry.swift
@@ -15,9 +15,7 @@ public struct Entry: Equatable {
 
     init(_ header: RARHeaderDataEx) {
         var _header: RARHeaderDataEx = header
-        self.fileName = withUnsafePointer(to: &_header.FileName.0) { ptr -> String in
-            return String(cString: UnsafeRawPointer(ptr).assumingMemoryBound(to: CChar.self))
-        }
+        self.fileName = withUnsafePointer(to: &_header.FileName.0) { String(cString: $0) }
         self.comment = _header.CmtBuf != nil ? String(cString: _header.CmtBuf) : nil
         self.uncompressedSize = UInt64(header.UnpSizeHigh) << 32 | UInt64(header.UnpSize)
         self.compressedSize = UInt64(header.PackSizeHigh) << 32 | UInt64(header.PackSize)


### PR DESCRIPTION
I was encountering a crash with an archive which worked fine in iOS 15 and works nicely in Catalyst. The crash reported was a string that was not null terminated. 

Using the unsafe pointer closure prevents this crash and functions as expected. 